### PR TITLE
Update definition to work without synthetic default imports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // TypeScript Version: 2.2.2
 
-import React from 'react'
+import * as React from 'react'
 
 interface TabsProps {
   /**


### PR DESCRIPTION
By changing react import to use `*` it allows the setting `allowSyntheticDefaultImports` to be false (default) on tsconfig.json files.