### PR TITLE
Added support for custom contents in tabs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -34,8 +34,6 @@ node_modules/react-native/flow/
 [options]
 module.system=haste
 
-experimental.strict_type_args=true
-
 munge_underscores=true
 
 module.name_mapper='^react-native$' -> 'emptyObject'
@@ -51,7 +49,5 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-6]\\|[1
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-6]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
-unsafe.enable_getters_and_setters=true
-
 [version]
-^0.56.0
+^0.79.1

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import MaterialTabs from 'react-native-material-tabs';
 | indicatorColor    | #fff                     | string        | Color of the indicator                                                                                  |
 | activeTextColor   | #fff                     | string        | Color of the text for the selected tab                                                                  |
 | inactiveTextColor | rgba(255, 255, 255, 0.7) | string        | Color of the text for inactive tabs                                                                     |
-| items             | none                     | array(string) | The headers for the individual tabs                                                                     |
+| items             | none                     | array(string|element) | The headers for the individual tabs                                                                     |
 | selectedIndex     | 0                        | number        | The index of current tab selected. Indexes are mapped to the items prop                                 |
 | scrollable        | false                    | boolean       | Option between having fixed tabs or scrollable tabs                                                     |
 | textStyle         | null                     | object(style) | Text style for tab titles                                                                               |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-react-native": "^2.3.2",
-    "flow-bin": "^0.56.0",
+    "flow-bin": "^0.79.1",
     "jest": "21.2.1",
     "prettier": "^1.9.1",
     "react": "16.0.0",

--- a/src/__tests__/__snapshots__/main.test.js.snap
+++ b/src/__tests__/__snapshots__/main.test.js.snap
@@ -741,3 +741,159 @@ exports[`Main should render without errors 1`] = `
   </RCTScrollView>
 </View>
 `;
+
+exports[`Main when items is an array of react elements should render tabs 1`] = `
+<View
+  barColor="#13897b"
+  barHeight={48}
+  onLayout={[Function]}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#13897b",
+        "height": 48,
+      },
+      undefined,
+    ]
+  }
+>
+  <RCTScrollView
+    horizontal={true}
+    scrollEnabled={false}
+    showsHorizontalScrollIndicator={false}
+  >
+    <View>
+      <View
+        barHeight={48}
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "height": 46,
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessibilityComponentType={undefined}
+          accessibilityLabel={undefined}
+          accessibilityTraits={undefined}
+          accessible={true}
+          collapsable={undefined}
+          hasTVPreferredFocus={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+              "width": 0,
+            }
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "height": 48,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 12,
+                },
+                undefined,
+              ]
+            }
+            tabHeight={48}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+            >
+              Tab1
+            </Text>
+          </View>
+        </View>
+        <View
+          accessibilityComponentType={undefined}
+          accessibilityLabel={undefined}
+          accessibilityTraits={undefined}
+          accessible={true}
+          collapsable={undefined}
+          hasTVPreferredFocus={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+              "width": 0,
+            }
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "height": 48,
+                  "justifyContent": "center",
+                  "paddingHorizontal": 12,
+                },
+                undefined,
+              ]
+            }
+            tabHeight={48}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+            >
+              Tab2
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        collapsable={undefined}
+        color="#fff"
+        style={
+          Object {
+            "backgroundColor": "#fff",
+            "bottom": 0,
+            "height": 2,
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+            ],
+            "width": 0,
+          }
+        }
+        tabWidth={0}
+      />
+    </View>
+  </RCTScrollView>
+</View>
+`;

--- a/src/__tests__/__snapshots__/main.test.js.snap
+++ b/src/__tests__/__snapshots__/main.test.js.snap
@@ -819,6 +819,14 @@ exports[`Main when items is an array of react elements should render tabs 1`] = 
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
+              style={
+                Array [
+                  undefined,
+                  Object {
+                    "color": "#fff",
+                  },
+                ]
+              }
             >
               Tab1
             </Text>
@@ -868,6 +876,14 @@ exports[`Main when items is an array of react elements should render tabs 1`] = 
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
+              style={
+                Array [
+                  undefined,
+                  Object {
+                    "color": "rgba(255, 255, 255, 0.7)",
+                  },
+                ]
+              }
             >
               Tab2
             </Text>

--- a/src/__tests__/components/Tab.test.js
+++ b/src/__tests__/components/Tab.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import Adapter from 'enzyme-adapter-react-16';
 import { create } from 'react-test-renderer';
-import { shallow, configure } from 'enzyme';
+import { configure } from 'enzyme';
 import Tab from '../../components/tab';
 import { Text } from 'react-native';
 
 configure({ adapter: new Adapter() });
 
-describe('Components | Tab', function () {
-  describe('when content is react element', function () {
-    it('renders content', function () {
+describe('Components | Tab', function() {
+  describe('when content is react element', function() {
+    it('renders content', function() {
       const component = (
         <Tab
-          allowFontScaling={true}
+          allowFontScaling
           content={<Text>hi</Text>}
           tabWidth={100}
           tabHeight={100}
@@ -20,18 +20,18 @@ describe('Components | Tab', function () {
           activeTextColor={'red'}
           inActiveTextColor={'green'}
           textStyle={false}
-          uppercase={true}
+          uppercase
         />
       );
       const tree = create(component).toJSON();
       expect(tree).toMatchSnapshot();
     });
   });
-  describe('when content is string', function () {
-    it('renders text tab', function () {
+  describe('when content is string', function() {
+    it('renders text tab', function() {
       const component = (
         <Tab
-          allowFontScaling={true}
+          allowFontScaling
           content={'text'}
           tabWidth={100}
           tabHeight={100}
@@ -39,7 +39,7 @@ describe('Components | Tab', function () {
           activeTextColor={'red'}
           inActiveTextColor={'green'}
           textStyle={false}
-          uppercase={true}
+          uppercase
         />
       );
       const tree = create(component).toJSON();

--- a/src/__tests__/components/Tab.test.js
+++ b/src/__tests__/components/Tab.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Adapter from 'enzyme-adapter-react-16';
+import { create } from 'react-test-renderer';
+import { shallow, configure } from 'enzyme';
+import Tab from '../../components/tab';
+import { Text } from 'react-native';
+
+configure({ adapter: new Adapter() });
+
+describe('Components | Tab', function () {
+  describe('when content is react element', function () {
+    it('renders content', function () {
+      const component = (
+        <Tab
+          allowFontScaling={true}
+          content={<Text>hi</Text>}
+          tabWidth={100}
+          tabHeight={100}
+          stretch={false}
+          activeTextColor={'red'}
+          inActiveTextColor={'green'}
+          textStyle={false}
+          uppercase={true}
+        />
+      );
+      const tree = create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  describe('when content is string', function () {
+    it('renders text tab', function () {
+      const component = (
+        <Tab
+          allowFontScaling={true}
+          content={'text'}
+          tabWidth={100}
+          tabHeight={100}
+          stretch={false}
+          activeTextColor={'red'}
+          inActiveTextColor={'green'}
+          textStyle={false}
+          uppercase={true}
+        />
+      );
+      const tree = create(component).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/__tests__/components/Tab.test.js
+++ b/src/__tests__/components/Tab.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Adapter from 'enzyme-adapter-react-16';
 import { create } from 'react-test-renderer';
 import { configure } from 'enzyme';
-import Tab from '../../components/tab';
+import Tab from '../../components/Tab';
 import { Text } from 'react-native';
 
 configure({ adapter: new Adapter() });

--- a/src/__tests__/components/__snapshots__/Tab.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Tab.test.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Components | Tab when content is react element renders content 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  collapsable={undefined}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+      "width": 100,
+    }
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "height": 100,
+          "justifyContent": "center",
+          "paddingHorizontal": 12,
+        },
+        undefined,
+      ]
+    }
+    tabHeight={100}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      hi
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`Components | Tab when content is string renders text tab 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  collapsable={undefined}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+      "width": 100,
+    }
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "height": 100,
+          "justifyContent": "center",
+          "paddingHorizontal": 12,
+        },
+        undefined,
+      ]
+    }
+    tabHeight={100}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      color="green"
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "green",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "minWidth": "100%",
+            "textAlign": "center",
+          },
+          Object {},
+        ]
+      }
+    >
+      TEXT
+    </Text>
+  </View>
+</View>
+`;

--- a/src/__tests__/components/__snapshots__/Tab.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Tab.test.js.snap
@@ -45,6 +45,14 @@ exports[`Components | Tab when content is react element renders content 1`] = `
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "color": "green",
+          },
+        ]
+      }
     >
       hi
     </Text>

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -131,15 +131,12 @@ describe('Main', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  describe('when items is an array of react elements', function () {
-    it('should render tabs', function () {
+  describe('when items is an array of react elements', function() {
+    it('should render tabs', function() {
       const tabs = (
         <MaterialTabs
           selectedIndex={0}
-          items={[
-            <Text>Tab1</Text>,
-            <Text>Tab2</Text>
-          ]}
+          items={[<Text key="1">Tab1</Text>, <Text key="2">Tab2</Text>]}
           onChange={onChange}
         />
       );

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import Adapter from 'enzyme-adapter-react-16';
 import { create } from 'react-test-renderer';
 import { shallow, configure } from 'enzyme';
@@ -128,5 +129,22 @@ describe('Main', () => {
 
     const tree = create(tabs).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  describe('when items is an array of react elements', function () {
+    it('should render tabs', function () {
+      const tabs = (
+        <MaterialTabs
+          selectedIndex={0}
+          items={[
+            <Text>Tab1</Text>,
+            <Text>Tab2</Text>
+          ]}
+          onChange={onChange}
+        />
+      );
+      const tree = create(tabs).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/MaterialTabs.js
+++ b/src/components/MaterialTabs.js
@@ -8,6 +8,7 @@ import { Bar, TabTrack } from '../lib/styles';
 import values from '../lib/values';
 import Tab from './Tab';
 import Indicator from './Indicator';
+import type { ContentType } from './Tab/Tab';
 
 type Props = {
   allowFontScaling: boolean,
@@ -20,7 +21,7 @@ type Props = {
   scrollable: boolean,
   textStyle: StyleObj,
   activeTextStyle: StyleObj,
-  items: string[],
+  items: ContentType[],
   uppercase: boolean,
   onChange: (index: number) => void,
 };
@@ -43,7 +44,7 @@ export default class MaterialTabs extends React.Component<Props, State> {
     scrollable: PropTypes.bool,
     textStyle: Text.propTypes.style,
     activeTextStyle: Text.propTypes.style,
-    items: PropTypes.arrayOf(PropTypes.string).isRequired,
+    items: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element])).isRequired,
     uppercase: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
   };
@@ -172,8 +173,8 @@ export default class MaterialTabs extends React.Component<Props, State> {
             {this.props.items.map((item, idx) => (
               <Tab
                 allowFontScaling={this.props.allowFontScaling}
-                text={item}
-                key={item}
+                content={item}
+                key={idx}
                 stretch={!this.props.scrollable}
                 onPress={() => this.props.onChange(idx)}
                 active={idx === this.props.selectedIndex}

--- a/src/components/MaterialTabs.js
+++ b/src/components/MaterialTabs.js
@@ -32,6 +32,8 @@ type State = {
   indicatorPosition: Animated.Value,
 };
 
+const getKeyForTab = (item: ContentType) => (typeof item == 'string') ? item : item.key;
+
 export default class MaterialTabs extends React.Component<Props, State> {
   static propTypes = {
     allowFontScaling: PropTypes.bool,
@@ -174,7 +176,7 @@ export default class MaterialTabs extends React.Component<Props, State> {
               <Tab
                 allowFontScaling={this.props.allowFontScaling}
                 content={item}
-                key={idx}
+                key={getKeyForTab(item)}
                 stretch={!this.props.scrollable}
                 onPress={() => this.props.onChange(idx)}
                 active={idx === this.props.selectedIndex}

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { Element } from 'react';
 import { StyleSheet } from 'react-native';
-import { TabText, TabBody, TabButton, IconStyle } from './styles';
+import { TabText, TabBody, TabButton } from './styles';
 import type { StyleObj } from '../../lib/definitions';
 
 export type ContentType = string | Element<*>;
@@ -35,7 +35,7 @@ const Tab = ({
   stretch,
   textStyle,
   uppercase,
-  activeTextStyle
+  activeTextStyle,
 }: TabProps) => {
   const color = active ? activeTextColor : inActiveTextColor;
   return (

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -1,13 +1,16 @@
 // @flow
 
 import React from 'react';
+import type { Element } from 'react';
 import { StyleSheet } from 'react-native';
-import { TabText, TabBody, TabButton } from './styles';
+import { TabText, TabBody, TabButton, IconStyle } from './styles';
 import type { StyleObj } from '../../lib/definitions';
+
+export type ContentType = string | Element<*>;
 
 type TabProps = {
   allowFontScaling: boolean,
-  text: string,
+  content: ContentType,
   tabWidth: number,
   tabHeight: number,
   stretch: boolean,
@@ -25,27 +28,40 @@ const Tab = ({
   activeTextColor,
   active,
   onPress,
-  text,
+  content,
   inActiveTextColor,
   tabWidth,
   tabHeight,
   stretch,
   textStyle,
   uppercase,
-  activeTextStyle,
+  activeTextStyle
 }: TabProps) => {
   const color = active ? activeTextColor : inActiveTextColor;
-
   return (
     <TabButton onPress={onPress} tabWidth={tabWidth} stretch={stretch}>
       <TabBody tabHeight={tabHeight}>
-        <TabText
-          color={color}
-          style={StyleSheet.flatten([textStyle, activeTextStyle])}
-          allowFontScaling={allowFontScaling}
-        >
-          {uppercase ? text.toUpperCase() : text}
-        </TabText>
+        {
+          (typeof content == 'string') ?
+          (
+            <TabText
+              color={color}
+              style={StyleSheet.flatten([textStyle, activeTextStyle])}
+              allowFontScaling={allowFontScaling}
+            >
+              {uppercase ? content.toUpperCase() : content}
+            </TabText>
+          ) :
+           React.cloneElement(
+            content,
+            {
+              style: [
+                content.props.style,
+                { color: color }
+              ]
+            }
+          )
+        }
       </TabBody>
     </TabButton>
   );

--- a/src/components/Tab/styles.js
+++ b/src/components/Tab/styles.js
@@ -28,6 +28,11 @@ type TabTextProps = {
   color: string,
 };
 
+export const IconStyle = {
+  fontSize: 28,
+  height: 30
+}
+
 export const TabText = styled.Text`
   color: ${(props: TabTextProps) => props.color};
   font-weight: ${Platform.OS === 'ios' ? 500 : 400};

--- a/src/components/Tab/styles.js
+++ b/src/components/Tab/styles.js
@@ -3,7 +3,6 @@
 import styled from 'styled-components';
 import { Platform } from 'react-native';
 import Button from '../Touchable';
-import type { StyleObj } from '../../lib/definitions';
 
 type TabBodyProps = {
   tabHeight: number,
@@ -27,11 +26,6 @@ export const TabButton = styled(Button)`
 type TabTextProps = {
   color: string,
 };
-
-export const IconStyle = {
-  fontSize: 28,
-  height: 30
-}
 
 export const TabText = styled.Text`
   color: ${(props: TabTextProps) => props.color};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StyleProp, TextStyle } from 'react-native';
+import type { ContentType } from './components/Tab/Tab';
 
 interface TabsProps {
   /**
@@ -59,9 +60,9 @@ interface TabsProps {
   scrollable?: boolean;
 
   /**
-   * The titles for the individual tabs
+   * The titles or elements for the individual tabs
    */
-  items: string[];
+  items: ContentType[];
 
   /**
    * Optional text style to pass to tab titles

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { StyleProp, TextStyle } from 'react-native';
-import type { ContentType } from './components/Tab/Tab';
 
 interface TabsProps {
   /**
@@ -62,7 +61,7 @@ interface TabsProps {
   /**
    * The titles or elements for the individual tabs
    */
-  items: ContentType[];
+  items: Array<string|React.Element>;
 
   /**
    * Optional text style to pass to tab titles

--- a/yarn.lock
+++ b/yarn.lock
@@ -4058,6 +4058,14 @@ react-is@^16.3.1:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
+react-native-vector-icons@^4.2.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
+  dependencies:
+    lodash "^4.0.0"
+    prop-types "^15.5.10"
+    yargs "^8.0.2"
+
 react-native@^0.51.0:
   version "0.51.0"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.0.tgz#fe25934b3030fd323f3ca1a70f034133465955ed"
@@ -5176,6 +5184,24 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,9 +2111,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.56.0:
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
+flow-bin@^0.79.1:
+  version "0.79.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.1.tgz#01c9f427baa6556753fa878c192d42e1ecb764b6"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -4058,14 +4058,6 @@ react-is@^16.3.1:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
-react-native-vector-icons@^4.2.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
-  dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.5.10"
-    yargs "^8.0.2"
-
 react-native@^0.51.0:
   version "0.51.0"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.0.tgz#fe25934b3030fd323f3ca1a70f034133465955ed"
@@ -5184,24 +5176,6 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
-
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
-  dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^7.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
Hi

I've added support for custom contents (like Icons, view) inside tabs.

Use case:
```jsx
import Ionicons from 'react-native-vector-icons/Ionicons';
import MaterialIcons from 'react-native-vector-icons/MaterialIcons';

....
<MaterialTabs
   items={[
     <Ionicons key='md-call' name='md-call' style={IconStyle}/>,
     <Ionicons key='md-globe' name='md-globe' style={IconStyle}/>,
     <Ionicons key='md-people' name='md-people' style={IconStyle}/>,
     <Ionicons key='md-settings' name='md-settings' style={IconStyle}/>
  ]}
 onChange={this.setTab.bind(this)}
/>

```