### PR TITLE
Fix `index.d.ts` w. `strictNullChecks` enabled

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,4 +88,4 @@ interface TabsProps {
   onChange(index: number): void;
 }
 
-export default class MaterialTabs extends React.Component<TabsProps, null> {}
+export default class MaterialTabs extends React.Component<TabsProps> {}


### PR DESCRIPTION
`State` type defaults to `{}` which can't be set to `null` when `strictNullChecks` is enabled.
It's not needed here so remove it.