### PR TITLE
v3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-tabs",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Material Design implementation of Tabs",
   "keywords": [
     "react",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,4 +88,4 @@ interface TabsProps {
   onChange(index: number): void;
 }
 
-export default class MaterialTabs extends React.Component<TabsProps, null> {}
+export default class MaterialTabs extends React.Component<TabsProps> {}


### PR DESCRIPTION
`State` type defaults to `{}` which can't be set to `null` when `strictNullChecks` is enabled.
It's not needed here so remove it.