### PR TITLE
Input field interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import MaterialTabs from 'react-native-material-tabs';
 | onChange          | none                     | Function      | Handler that's emitted every time the user presses a tab. You can use this to change the selected index |
 | allowFontScaling  | true                     | boolean       | Specifies whether fonts should scale to respect Text Size accessibility settings                        |
 | uppercase         | true                     | boolean       | Specifies whether to uppercase the tab labels                                                           |
-| keyboardShouldPersistTaps | 'never'          | string | Specifies how the [ScrollView](https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps) should respond to taps while keyboard is open                          |
+| keyboardShouldPersistTaps | never          | string | Specifies how the [ScrollView](https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps) should respond to taps while keyboard is open                          |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import MaterialTabs from 'react-native-material-tabs';
 | onChange          | none                     | Function      | Handler that's emitted every time the user presses a tab. You can use this to change the selected index |
 | allowFontScaling  | true                     | boolean       | Specifies whether fonts should scale to respect Text Size accessibility settings                        |
 | uppercase         | true                     | boolean       | Specifies whether to uppercase the tab labels                                                           |
+| keyboardShouldPersistTaps | 'never'          | string \| boolean | Specifies how the ScrollView should respond to taps while keyboard is open                          |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import MaterialTabs from 'react-native-material-tabs';
 | onChange          | none                     | Function      | Handler that's emitted every time the user presses a tab. You can use this to change the selected index |
 | allowFontScaling  | true                     | boolean       | Specifies whether fonts should scale to respect Text Size accessibility settings                        |
 | uppercase         | true                     | boolean       | Specifies whether to uppercase the tab labels                                                           |
-| keyboardShouldPersistTaps | 'never'          | string \| boolean | Specifies how the ScrollView should respond to taps while keyboard is open                          |
+| keyboardShouldPersistTaps | 'never'          | string | Specifies how the [ScrollView](https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps) should respond to taps while keyboard is open                          |
 
 ## Example
 

--- a/src/__tests__/__snapshots__/main.test.js.snap
+++ b/src/__tests__/__snapshots__/main.test.js.snap
@@ -17,6 +17,7 @@ exports[`Main should apply custom activeTextStyle to active tab 1`] = `
 >
   <RCTScrollView
     horizontal={true}
+    keyboardShouldPersistTaps="never"
     scrollEnabled={false}
     showsHorizontalScrollIndicator={false}
   >
@@ -203,6 +204,7 @@ exports[`Main should apply custom fontFamily to tab 1`] = `
 >
   <RCTScrollView
     horizontal={true}
+    keyboardShouldPersistTaps="never"
     scrollEnabled={false}
     showsHorizontalScrollIndicator={false}
   >
@@ -391,6 +393,7 @@ exports[`Main should display tab labels not uppercased 1`] = `
 >
   <RCTScrollView
     horizontal={true}
+    keyboardShouldPersistTaps="never"
     scrollEnabled={false}
     showsHorizontalScrollIndicator={false}
   >
@@ -575,6 +578,7 @@ exports[`Main should render without errors 1`] = `
 >
   <RCTScrollView
     horizontal={true}
+    keyboardShouldPersistTaps="never"
     scrollEnabled={false}
     showsHorizontalScrollIndicator={false}
   >

--- a/src/components/MaterialTabs.js
+++ b/src/components/MaterialTabs.js
@@ -23,6 +23,7 @@ type Props = {
   items: string[],
   uppercase: boolean,
   onChange: (index: number) => void,
+  keyboardShouldPersistTaps: string | boolean,
 };
 
 type State = {
@@ -46,6 +47,9 @@ export default class MaterialTabs extends React.Component<Props, State> {
     items: PropTypes.arrayOf(PropTypes.string).isRequired,
     uppercase: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
+    keyboardShouldPersistTaps: PropTypes.oneOfType([
+      PropTypes.string, PropTypes.bool
+    ]),
   };
 
   static defaultProps = {
@@ -60,6 +64,7 @@ export default class MaterialTabs extends React.Component<Props, State> {
     textStyle: null,
     uppercase: true,
     activeTextStyle: {},
+    keyboardShouldPersistTaps: 'never',
   };
 
   state = {
@@ -166,6 +171,7 @@ export default class MaterialTabs extends React.Component<Props, State> {
           horizontal
           ref={ref => (this.scrollView = ref)}
           showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
           scrollEnabled={this.props.scrollable}
         >
           <TabTrack barHeight={this.props.barHeight}>

--- a/src/components/MaterialTabs.js
+++ b/src/components/MaterialTabs.js
@@ -23,7 +23,7 @@ type Props = {
   items: string[],
   uppercase: boolean,
   onChange: (index: number) => void,
-  keyboardShouldPersistTaps: string | boolean,
+  keyboardShouldPersistTaps: string,
 };
 
 type State = {
@@ -47,9 +47,7 @@ export default class MaterialTabs extends React.Component<Props, State> {
     items: PropTypes.arrayOf(PropTypes.string).isRequired,
     uppercase: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
-    keyboardShouldPersistTaps: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.bool
-    ]),
+    keyboardShouldPersistTaps: PropTypes.string,
   };
 
   static defaultProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -86,6 +86,13 @@ interface TabsProps {
    * @param index
    */
   onChange(index: number): void;
+
+  /**
+   * Optional keyboard tap behaviour for the ScrollView.
+   * See: https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps
+   * Default 'none'.
+   */
+  keyboardShouldPersistTaps?: string;
 }
 
 export default class MaterialTabs extends React.Component<TabsProps> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,7 +92,7 @@ interface TabsProps {
    * See: https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps
    * Default 'none'.
    */
-  keyboardShouldPersistTaps?: string;
+  keyboardShouldPersistTaps?: "always" | "never" | "handled";
 }
 
 export default class MaterialTabs extends React.Component<TabsProps> {}


### PR DESCRIPTION
Preamble
----------
If there's a nicer solution I'm open to suggestions! This change will make MaterialTabs friendlier to use on pages with input fields.

Explanation
------------
While an input field has focus, MaterialTabs is not immediately responsive to taps. This is an [interaction](https://stackoverflow.com/questions/35122327/catch-tap-in-react-native-scrollview-while-keyboard-is-up) between the keyboard and ScrollView. At the moment MaterialTabs needs to be tapped twice in order to trigger its press event while an input field is focussed.

This PR allows `keyboardShouldPersistTaps` to be passed as a prop to the MaterialTabs ScrollView. In the following usage example, MaterialTabs will immediately receive a tap while an input field has focus.

```jsx
<MaterialTabs keyboardShouldPersistTaps="always" />
```

