### PR TITLE
Feature icon with label

### DIFF
--- a/src/__tests__/__snapshots__/main.test.js.snap
+++ b/src/__tests__/__snapshots__/main.test.js.snap
@@ -1,323 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Main should apply custom activeTextStyle to active tab 1`] = `
-<View
-  barColor="#13897b"
-  barHeight={48}
-  onLayout={[Function]}
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#13897b",
-        "height": 48,
-      },
-    ]
-  }
->
-  <RCTScrollView
-    horizontal={true}
-    keyboardShouldPersistTaps="never"
-    scrollEnabled={false}
-    showsHorizontalScrollIndicator={false}
-  >
-    <View>
-      <View
-        barHeight={48}
-        style={
-          Array [
-            Object {
-              "flexDirection": "row",
-              "height": 46,
-            },
-          ]
-        }
-      >
-        <View
-          accessible={true}
-          isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-              "width": 0,
-            }
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "paddingHorizontal": 12,
-                },
-              ]
-            }
-            tabHeight={48}
-          >
-            <Text
-              allowFontScaling={true}
-              color="#fff"
-              style={
-                Array [
-                  Object {
-                    "color": "#fff",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "minWidth": "100%",
-                    "textAlign": "center",
-                  },
-                  Object {
-                    "color": "pink",
-                  },
-                ]
-              }
-            >
-              TAB1
-            </Text>
-          </View>
-        </View>
-        <View
-          accessible={true}
-          isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-              "width": 0,
-            }
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "paddingHorizontal": 12,
-                },
-              ]
-            }
-            tabHeight={48}
-          >
-            <Text
-              allowFontScaling={true}
-              color="rgba(255, 255, 255, 0.7)"
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(255, 255, 255, 0.7)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "minWidth": "100%",
-                    "textAlign": "center",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              TAB2
-            </Text>
-          </View>
-        </View>
-      </View>
-      <View
-        color="#fff"
-        style={
-          Object {
-            "backgroundColor": "#fff",
-            "bottom": 0,
-            "height": 2,
-            "position": "absolute",
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-            ],
-            "width": 0,
-          }
-        }
-        tabWidth={0}
-      />
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`Main should apply custom fontFamily to tab 1`] = `
-<View
-  barColor="#13897b"
-  barHeight={48}
-  onLayout={[Function]}
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#13897b",
-        "height": 48,
-      },
-    ]
-  }
->
-  <RCTScrollView
-    horizontal={true}
-    keyboardShouldPersistTaps="never"
-    scrollEnabled={false}
-    showsHorizontalScrollIndicator={false}
-  >
-    <View>
-      <View
-        barHeight={48}
-        style={
-          Array [
-            Object {
-              "flexDirection": "row",
-              "height": 46,
-            },
-          ]
-        }
-      >
-        <View
-          accessible={true}
-          isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-              "width": 0,
-            }
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "paddingHorizontal": 12,
-                },
-              ]
-            }
-            tabHeight={48}
-          >
-            <Text
-              allowFontScaling={true}
-              color="#fff"
-              style={
-                Array [
-                  Object {
-                    "color": "#fff",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "minWidth": "100%",
-                    "textAlign": "center",
-                  },
-                  Object {
-                    "fontFamily": "Papyrus",
-                  },
-                ]
-              }
-            >
-              TAB1
-            </Text>
-          </View>
-        </View>
-        <View
-          accessible={true}
-          isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "opacity": 1,
-              "width": 0,
-            }
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "paddingHorizontal": 12,
-                },
-              ]
-            }
-            tabHeight={48}
-          >
-            <Text
-              allowFontScaling={true}
-              color="rgba(255, 255, 255, 0.7)"
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(255, 255, 255, 0.7)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "minWidth": "100%",
-                    "textAlign": "center",
-                  },
-                  Object {
-                    "fontFamily": "Papyrus",
-                  },
-                ]
-              }
-            >
-              TAB2
-            </Text>
-          </View>
-        </View>
-      </View>
-      <View
-        color="#fff"
-        style={
-          Object {
-            "backgroundColor": "#fff",
-            "bottom": 0,
-            "height": 2,
-            "position": "absolute",
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-            ],
-            "width": 0,
-          }
-        }
-        tabWidth={0}
-      />
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
 exports[`Main should display tab labels not uppercased 1`] = `
 <View
   barColor="#13897b"
@@ -382,6 +64,7 @@ exports[`Main should display tab labels not uppercased 1`] = `
             <Text
               allowFontScaling={true}
               color="#fff"
+              marginLeft={false}
               style={
                 Array [
                   Object {
@@ -389,7 +72,7 @@ exports[`Main should display tab labels not uppercased 1`] = `
                     "fontFamily": "System",
                     "fontSize": 14,
                     "fontWeight": "500",
-                    "minWidth": "100%",
+                    "marginLeft": 0,
                     "textAlign": "center",
                   },
                   Object {},
@@ -432,6 +115,7 @@ exports[`Main should display tab labels not uppercased 1`] = `
             <Text
               allowFontScaling={true}
               color="rgba(255, 255, 255, 0.7)"
+              marginLeft={false}
               style={
                 Array [
                   Object {
@@ -439,7 +123,7 @@ exports[`Main should display tab labels not uppercased 1`] = `
                     "fontFamily": "System",
                     "fontSize": 14,
                     "fontWeight": "500",
-                    "minWidth": "100%",
+                    "marginLeft": 0,
                     "textAlign": "center",
                   },
                   Object {},
@@ -538,6 +222,7 @@ exports[`Main should render without errors 1`] = `
             <Text
               allowFontScaling={true}
               color="#fff"
+              marginLeft={false}
               style={
                 Array [
                   Object {
@@ -545,7 +230,7 @@ exports[`Main should render without errors 1`] = `
                     "fontFamily": "System",
                     "fontSize": 14,
                     "fontWeight": "500",
-                    "minWidth": "100%",
+                    "marginLeft": 0,
                     "textAlign": "center",
                   },
                   Object {},
@@ -588,6 +273,7 @@ exports[`Main should render without errors 1`] = `
             <Text
               allowFontScaling={true}
               color="rgba(255, 255, 255, 0.7)"
+              marginLeft={false}
               style={
                 Array [
                   Object {
@@ -595,7 +281,7 @@ exports[`Main should render without errors 1`] = `
                     "fontFamily": "System",
                     "fontSize": 14,
                     "fontWeight": "500",
-                    "minWidth": "100%",
+                    "marginLeft": 0,
                     "textAlign": "center",
                   },
                   Object {},

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -2,9 +2,8 @@
 
 import React from 'react';
 import type { Element } from 'react';
-import { StyleSheet } from 'react-native';
-import { TabButton } from './styles';
-import { TabItem } from './TabItem';
+import { TabBody, TabButton } from './styles';
+import TabItem from './TabItem';
 
 export type ContentType = string | Element<*>;
 

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -3,7 +3,8 @@
 import React from 'react';
 import type { Element } from 'react';
 import { StyleSheet } from 'react-native';
-import { TabText, TabBody, TabButton } from './styles';
+import { TabButton } from './styles';
+import { TabItem } from './TabItem';
 
 export type ContentType = string | Element<*>;
 
@@ -41,19 +42,14 @@ const Tab = ({
   return (
     <TabButton onPress={onPress} tabWidth={tabWidth} stretch={stretch}>
       <TabBody tabHeight={tabHeight}>
-        {typeof content === 'string' ? (
-          <TabText
-            color={color}
-            style={StyleSheet.flatten([textStyle, activeTextStyle])}
-            allowFontScaling={allowFontScaling}
-          >
-            {uppercase ? content.toUpperCase() : content}
-          </TabText>
-        ) : (
-          React.cloneElement(content, {
-            style: [content.props.style, { color }],
-          })
-        )}
+        <TabItem
+          activeTextStyle={activeTextStyle}
+          allowFontScaling={allowFontScaling}
+          color={color}
+          content={content}
+          uppercase={uppercase}
+          textStyle={textStyle}
+        />
       </TabBody>
     </TabButton>
   );

--- a/src/components/Tab/TabItem.js
+++ b/src/components/Tab/TabItem.js
@@ -1,0 +1,56 @@
+// @flow
+
+import React from 'react';
+import type { Element } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import { TabText } from './styles';
+
+export type ContentType = string | Element<*>;
+
+type TabItemProps = {
+  activeTextStyle: any,
+  allowFontScaling: boolean,
+  color: string,
+  content: ContentType,
+  textStyle: any,
+  uppercase: boolean,
+};
+
+const TabItem = ({
+  activeTextStyle,
+  allowFontScaling,
+  color,
+  content,
+  textStyle,
+  uppercase
+}: TabItemProps) => {
+  // Just render the simple text
+  if (typeof content === 'string') {
+    return (
+      <TabText
+        color={color}
+        style={StyleSheet.flatten([textStyle, activeTextStyle])}
+        allowFontScaling={allowFontScaling}
+      >
+        {uppercase ? content.toUpperCase() : content}
+      </TabText>
+    );
+  }
+  // if has a props.type should be icon + label style
+  if (content.props.type) {
+    return (
+      React.cloneElement(content, {
+        style: [content.props.style, { color }],
+      })
+    );
+  }
+  // return just the icon
+  return (
+    React.cloneElement(content, {
+      style: [content.props.style, { color }],
+    })
+  );
+}
+
+export default TabItem;

--- a/src/components/Tab/TabItem.js
+++ b/src/components/Tab/TabItem.js
@@ -1,20 +1,29 @@
 // @flow
 
 import React from 'react';
-import type { Element } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 import { TabText } from './styles';
-
-export type ContentType = string | Element<*>;
 
 type TabItemProps = {
   activeTextStyle: any,
   allowFontScaling: boolean,
   color: string,
-  content: ContentType,
+  content: any,
   textStyle: any,
   uppercase: boolean,
+};
+
+// Helper fn to get the text from Element or just string and convert or no to upper case
+const getText = (content, uppercase): string => {
+  let text = '';
+  if (typeof content === 'string') {
+    text = content;
+  } else if (content.props.text) {
+    // eslint-disable-next-line prefer-destructuring
+    text = content.props.text;
+  }
+  return uppercase ? text.toUpperCase() : text;
 };
 
 const TabItem = ({
@@ -23,34 +32,41 @@ const TabItem = ({
   color,
   content,
   textStyle,
-  uppercase
+  uppercase,
 }: TabItemProps) => {
   // Just render the simple text
+  const text = (
+    <TabText
+      color={color}
+      style={StyleSheet.flatten([textStyle, activeTextStyle])}
+      allowFontScaling={allowFontScaling}
+      marginLeft={content.props ? !content.props.vertical : false}
+    >
+      {getText(content, uppercase)}
+    </TabText>
+  );
   if (typeof content === 'string') {
-    return (
-      <TabText
-        color={color}
-        style={StyleSheet.flatten([textStyle, activeTextStyle])}
-        allowFontScaling={allowFontScaling}
-      >
-        {uppercase ? content.toUpperCase() : content}
-      </TabText>
-    );
+    return text;
   }
-  // if has a props.type should be icon + label style
-  if (content.props.type) {
+  const icon = React.cloneElement(content, {
+    style: [content.props.style, { color }],
+  });
+  // if has a props.text should be icon + label style
+  if (content.props.text) {
+    const alignmentStyle = {
+      alignItems: 'center',
+      flexDirection: !content.props.vertical ? 'row' : 'column',
+      justifyContent: 'center',
+    };
     return (
-      React.cloneElement(content, {
-        style: [content.props.style, { color }],
-      })
+      <View style={alignmentStyle}>
+        {icon}
+        {text}
+      </View>
     );
   }
   // return just the icon
-  return (
-    React.cloneElement(content, {
-      style: [content.props.style, { color }],
-    })
-  );
-}
+  return icon;
+};
 
 export default TabItem;

--- a/src/components/Tab/__tests__/__snapshots__/Tab.test.js.snap
+++ b/src/components/Tab/__tests__/__snapshots__/Tab.test.js.snap
@@ -79,6 +79,7 @@ exports[`Components | Tab when content is string renders text tab 1`] = `
     <Text
       allowFontScaling={true}
       color="green"
+      marginLeft={false}
       style={
         Array [
           Object {
@@ -86,7 +87,7 @@ exports[`Components | Tab when content is string renders text tab 1`] = `
             "fontFamily": "System",
             "fontSize": 14,
             "fontWeight": "500",
-            "minWidth": "100%",
+            "marginLeft": 0,
             "textAlign": "center",
           },
           Object {},

--- a/src/components/Tab/styles.js
+++ b/src/components/Tab/styles.js
@@ -25,6 +25,7 @@ export const TabButton = styled(Button)`
 
 type TabTextProps = {
   color: string,
+  marginLeft: boolean,
 };
 
 export const TabText = styled.Text`
@@ -32,6 +33,6 @@ export const TabText = styled.Text`
   font-weight: ${Platform.OS === 'ios' ? 500 : 400};
   font-family: ${Platform.OS === 'android' ? 'sans-serif-medium' : 'System'};
   font-size: 14;
+  margin-left: ${(props: TabTextProps) => (props.marginLeft ? 8 : 0)};
   text-align: center;
-  min-width: 100%;
 `;


### PR DESCRIPTION
Hi,

this PR closes #34

Two tests are failing now due the the changes in Tab.js, now there is a minor block stateless component TabItem, I was thinking about the logic to show the vertical/horizontal(label+element) and thought that splitting this if/else/styling questions into a minor stateless component was more easy to understand.

**NOTE: PLEASE, DO NOT MERGE YET, STILL WIP**

![image](https://user-images.githubusercontent.com/15792853/54032036-3feaec00-418f-11e9-9d0f-b6933b2d48d9.png)

Now we can pass two props when passing an Element, *text<string>* and *vertical<boolean>*, as the name says if we pass the *text* will show by default the Element + text horizontally, and if we pass *vertical*(value true) the Element + text will be shown vertically, in this order as the image above shows up.

how to use:
```javascript
import Ionicons from 'react-native-vector-icons/Ionicons';
import MaterialIcons from 'react-native-vector-icons/MaterialIcons';

....
<MaterialTabs
  items={[
    'One',
    <Ionicons key='md-globe' name='md-globe' />,
    <Ionicons key='md-globe' name='md-globe' text='map' vertical/>,
    <Ionicons key='md-call' name='md-call' text='call' />,
  ]}
  barColor="#1fbcd2"
  indicatorColor="#fffe94"
  activeTextColor="white"
/>
```

I would like to change the two failing tests to match the new changes, I think this won't be a breaking change to the lib, just the shallow navigation inside of the component is messy right now. So, may I change those 2 failing tests and add 2-3 more tests for the new features?