### PR TITLE
Adds tabWidth prop to component

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,15 @@ interface TabsProps {
   barHeight?: number;
 
   /**
+   * Width of each tab as a number or string. Absolute or percentage values.
+   *
+   * e.g. 165, "165", or "20%"
+   *
+   * Default is 40%
+   */
+  tabWidth?: number | string;
+
+  /**
    * Color of the text for the selected tab
    *
    * Default is #fff

--- a/src/lib/values.js
+++ b/src/lib/values.js
@@ -2,5 +2,6 @@
 
 export default {
   barHeight: 48,
+  tabWidth: '40%',
   indicatorHeight: 2,
 };


### PR DESCRIPTION
- Adds tab width prop to allow user to specify tab width as a number or string e.g. 165 or “165”. Also allows user to specify relative percentage width e.g. “20%”
- Dry up repeated tab width calculations in JSX by holding pre-calculated value in state