### PR TITLE
Adds tabWidth prop to component

### DIFF
--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -146,4 +146,38 @@ describe('Main', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe('Parsing user defined tabWidth', () => {
+    const mockBarWidth = 100;
+
+    it('should parse asbolute width as number', () => {
+      const expected = 300;
+      const userInput = 300;
+      const actual = MaterialTabs.parseUserDefinedTabWidth(
+        mockBarWidth,
+        userInput
+      );
+      expect(actual).toBe(expected);
+    });
+
+    it('should parse asbolute width as string', () => {
+      const expected = 300;
+      const userInput = '300';
+      const actual = MaterialTabs.parseUserDefinedTabWidth(
+        mockBarWidth,
+        userInput
+      );
+      expect(actual).toBe(expected);
+    });
+
+    it('should parse relative width as percentage', () => {
+      const expected = 20;
+      const userInput = '20%';
+      const actual = MaterialTabs.parseUserDefinedTabWidth(
+        mockBarWidth,
+        userInput
+      );
+      expect(actual).toBe(expected);
+    });
+  });
 });

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -147,6 +147,20 @@ describe('Main', () => {
     });
   });
 
+  it('should not move indicator or scroll when first tab is selected', () => {
+    const items = ['Tab1', 'Tab2'];
+    const tabs = new MaterialTabs({
+      selectedIndex: 0,
+      items,
+      tabWidth: 100,
+      onChange,
+      uppercase: false,
+    });
+    const { indicatorPosition, scrollPosition } = tabs.getAnimateValues();
+    expect(indicatorPosition).toBe(0);
+    expect(scrollPosition).toBe(0);
+  });
+
   describe('Parsing user defined tabWidth', () => {
     const mockBarWidth = 100;
 

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -147,18 +147,35 @@ describe('Main', () => {
     });
   });
 
-  it('should not move indicator or scroll when first tab is selected', () => {
-    const items = ['Tab1', 'Tab2'];
-    const tabs = new MaterialTabs({
-      selectedIndex: 0,
-      items,
-      tabWidth: 100,
-      onChange,
-      uppercase: false,
+  describe('indicator and scroll position values', () => {
+    it('should not move indicator or scroll when first tab is selected', () => {
+      const items = ['Tab1', 'Tab2'];
+      const tabs = new MaterialTabs({
+        selectedIndex: 0,
+        items,
+        tabWidth: 100,
+        onChange,
+        uppercase: false,
+      });
+      const { indicatorPosition, scrollPosition } = tabs.getAnimateValues();
+      expect(indicatorPosition).toBe(0);
+      expect(scrollPosition).toBe(0);
     });
-    const { indicatorPosition, scrollPosition } = tabs.getAnimateValues();
-    expect(indicatorPosition).toBe(0);
-    expect(scrollPosition).toBe(0);
+
+    it('should return end value is passed maximum index', () => {
+      const items = ['Tab1', 'Tab2', 'Tab3', 'Tab4', 'Tab5', 'Tab6'];
+      const tabs = new MaterialTabs({
+        selectedIndex: 4,
+        items,
+        tabWidth: 100,
+        onChange,
+        uppercase: false,
+        scrollable: true,
+      });
+      tabs.state = { ...tabs.state, barWidth: 300, tabWidth: 100 };
+      const { scrollPosition } = tabs.getAnimateValues();
+      expect(scrollPosition).toBe('end');
+    });
   });
 
   describe('Parsing user defined tabWidth', () => {

--- a/src/components/MaterialTabs.js
+++ b/src/components/MaterialTabs.js
@@ -123,16 +123,12 @@ export default class MaterialTabs extends React.Component<Props, State> {
     const isMaximumScroll = (index: number) =>
       tabWidth * index + barWidth / 2 > contentSize;
 
-    let maximumIndex;
+    let maximumIndex = 0;
 
     for (let i = lastIndex; i >= 0 && !maximumIndex; i -= 1) {
       if (!isMaximumScroll(i)) {
         maximumIndex = i;
       }
-    }
-
-    if (typeof maximumIndex === 'undefined') {
-      throw new Error('Unexpected failure to calculate maximum Index');
     }
 
     if (indicatorPosition < midpoint) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,15 @@ interface TabsProps {
   barHeight?: number;
 
   /**
+   * Width of each tab as a number or string. Absolute or percentage values.
+   *
+   * e.g. 165, "165", or "20%"
+   *
+   * Default is 40%
+   */
+  tabWidth?: number | string;
+
+  /**
    * Color of the text for the selected tab
    *
    * Default is #fff

--- a/src/lib/values.js
+++ b/src/lib/values.js
@@ -2,5 +2,6 @@
 
 export default {
   barHeight: 48,
+  tabWidth: '40%',
   indicatorHeight: 2,
 };


### PR DESCRIPTION
- Adds tab width prop to allow user to specify tab width as a number or string e.g. 165 or “165”. Also allows user to specify relative percentage width e.g. “20%”
- Dry up repeated tab width calculations in JSX by moving the calcultaion to the moment prior to storing in state.
- Update indicator and scroll calculations to support smaller tab widths

Default Tab Size
![default_size](https://user-images.githubusercontent.com/20878393/54778288-a853b780-4bea-11e9-8f14-0c9b0f04291c.gif)

Super Small Tab Size
![super_small](https://user-images.githubusercontent.com/20878393/54778298-af7ac580-4bea-11e9-9575-e083559cd7cc.gif)
