### PR TITLE
Default value for getTabWidth

### DIFF
--- a/src/components/MaterialTabs.tsx
+++ b/src/components/MaterialTabs.tsx
@@ -58,7 +58,7 @@ const MaterialTabs: React.FC<Props> = ({
   const bar = React.createRef<View>();
 
   const getTabWidth = useCallback(
-    (width: number) => {
+    (width: number = 0) => {
       if (!scrollable) {
         setTabWidth(width / items.length);
       }


### PR DESCRIPTION
On Android it seems measure can fire on a ref but sometimes return undefined for the width. Having a default value ensures it doesn't throw a `Malformed calls from JS: field sizes are different` error in this case